### PR TITLE
Fix progress bar

### DIFF
--- a/toga_gtk/widgets/progressbar.py
+++ b/toga_gtk/widgets/progressbar.py
@@ -11,16 +11,16 @@ class ProgressBar(Widget):
         super(ProgressBar, self).__init__()
 
         self.max = max
-
+        self._running = True
+        self._value = value
+    
         self.startup()
-
-        self.value = value
 
     def startup(self):
         self._impl = Gtk.ProgressBar()
 
         if self._running:
-            self._impl.set_fraction(float(value) / float(max))
+            self._impl.set_fraction(float(self._value) / float(self.max))
 
     @property
     def value(self):

--- a/toga_gtk/widgets/progressbar.py
+++ b/toga_gtk/widgets/progressbar.py
@@ -30,7 +30,7 @@ class ProgressBar(Widget):
     def value(self, value):
         self._value = value
         self._running = self._value is not None
-        self._impl.set_fraction(float(value) / float(max))
+        self._impl.set_fraction(float(value) / float(self.max))
 
     def start(self):
         if not self._running:

--- a/toga_gtk/widgets/progressbar.py
+++ b/toga_gtk/widgets/progressbar.py
@@ -16,7 +16,7 @@ class ProgressBar(Widget):
 
         self.value = value
 
-    def _startup(self):
+    def startup(self):
         self._impl = Gtk.ProgressBar()
 
         if self._running:


### PR DESCRIPTION
When I try to use the ProgressBar in Linux, I get following error
```
    gui = LoadBalance('LoadBalance', 'cs423.load_balance')
  File "gui.py", line 16, in __init__
    self.progress_bar = toga.ProgressBar(1024, 0)
  File "/usr/local/lib/python2.7/dist-packages/toga_gtk/widgets/progressbar.py", line 15, in __init__
    self.startup()
AttributeError: 'ProgressBar' object has no attribute 'startup'
```
I think it is caused by this typo