### PR TITLE
use try...except in TextInput.value to account for python 3 strings

### DIFF
--- a/toga_gtk/widgets/textinput.py
+++ b/toga_gtk/widgets/textinput.py
@@ -35,4 +35,7 @@ class TextInput(Widget):
 
     @value.setter
     def value(self, value):
-        self._impl.set_text(unicode(value))
+        try:
+            self._impl.set_text(unicode(value))
+        except NameError as python3_strings:  # avoids use of 2to3 on all of toga
+            self._impl.set_text(str(value))


### PR DESCRIPTION
Is this ok?

I came across an import error when making the "farenheit to celsius" converter tutorial. I thought catching the ImportError might be good.