### PR TITLE
Add font support to GTK and fix a pile of bugs

### DIFF
--- a/toga_gtk/__init__.py
+++ b/toga_gtk/__init__.py
@@ -2,6 +2,7 @@
 from .app import *
 from .window import *
 from .command import *
+from .font import Font
 
 # Widgets
 from .widgets.button import *
@@ -27,6 +28,7 @@ __all__ = [
     'Box',
     'Button',
     'Icon', 'TIBERIUS_ICON',
+    'Font',
     'Label',
     # 'MultilineTextInput',
     'OptionContainer',

--- a/toga_gtk/font.py
+++ b/toga_gtk/font.py
@@ -9,4 +9,4 @@ class Font(FontInterface):
 
     def create(self):
         self._impl = Pango.FontDescription.from_string(
-            "'" + self.family + "' " + str(self.size))
+            self.family + " " + str(self.size))

--- a/toga_gtk/font.py
+++ b/toga_gtk/font.py
@@ -1,0 +1,12 @@
+from toga.interface import Font as FontInterface
+
+import gi
+gi.require_version("Pango", "1.0")
+from gi.repository import Pango
+
+
+class Font(FontInterface):
+
+    def create(self):
+        self._impl = Pango.FontDescription.from_string(
+            "'" + self.family + "' " + str(self.size))

--- a/toga_gtk/widgets/base.py
+++ b/toga_gtk/widgets/base.py
@@ -1,3 +1,4 @@
+from gi.repository import Gtk
 
 def wrapped_handler(widget, handler):
     def _handler(impl, data=None):
@@ -24,3 +25,6 @@ class WidgetMixin:
 
     def _apply_layout(self):
         pass
+
+    def _set_font(self, font):
+        self._impl.override_font(font._impl)

--- a/toga_gtk/widgets/button.py
+++ b/toga_gtk/widgets/button.py
@@ -23,12 +23,12 @@ class Button(ButtonInterface, WidgetMixin):
         self.rehint()
 
     def _set_on_press(self, handler):
-        for conn_id in self.connections:
+        for conn_id in self._connections:
             # Disconnect all other on-click handlers, so that if you reassign
             # the on_press, it doesn't trigger the old ones too.
             self._impl.disconnect(conn_id)
 
-        self.connections.append(
+        self._connections.append(
             self._impl.connect("clicked", wrapped_handler(self, handler)))
 
     def rehint(self):

--- a/toga_gtk/widgets/button.py
+++ b/toga_gtk/widgets/button.py
@@ -8,9 +8,9 @@ from ..utils import wrapped_handler
 
 class Button(ButtonInterface, WidgetMixin):
     def __init__(self, label, id=None, style=None, on_press=None):
+        self._connections = []
         super().__init__(label, id=id, style=style, on_press=on_press)
         self._create()
-        self._connections = []
 
     def create(self):
         self._impl = Gtk.Button()

--- a/toga_gtk/widgets/button.py
+++ b/toga_gtk/widgets/button.py
@@ -10,6 +10,7 @@ class Button(ButtonInterface, WidgetMixin):
     def __init__(self, label, id=None, style=None, on_press=None):
         super().__init__(label, id=id, style=style, on_press=on_press)
         self._create()
+        self._connections = []
 
     def create(self):
         self._impl = Gtk.Button()
@@ -22,7 +23,13 @@ class Button(ButtonInterface, WidgetMixin):
         self.rehint()
 
     def _set_on_press(self, handler):
-        self._impl.connect("clicked", wrapped_handler(self, handler))
+        for conn_id in self.connections:
+            # Disconnect all other on-click handlers, so that if you reassign
+            # the on_press, it doesn't trigger the old ones too.
+            self._impl.disconnect(conn_id)
+
+        self.connections.append(
+            self._impl.connect("clicked", wrapped_handler(self, handler)))
 
     def rehint(self):
         # print("REHINT", self, self._impl.get_preferred_width(), self._impl.get_preferred_height(), getattr(self, '_fixed_height', False), getattr(self, '_fixed_width', False))

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -12,6 +12,7 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
     def __init__(self, id=None, style=None, horizontal=True, vertical=True, content=None):
         super().__init__(id=id, style=style, horizontal=horizontal, vertical=vertical, content=content)
         self._create()
+        self._interface = self
 
     def create(self):
         self._impl = Gtk.ScrolledWindow()

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -18,7 +18,10 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
         self._impl._interface = self
 
     def _set_content(self, container, widget):
-        self._impl.add_with_viewport(container._impl)
+        if self._impl.get_child():
+            self._impl.remove(self._impl.get_child())
+
+        self._impl.add(container._impl)
 
     def _set_app(self, app):
         if self._content:

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -12,10 +12,10 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
     def __init__(self, id=None, style=None, horizontal=True, vertical=True, content=None):
         super().__init__(id=id, style=style, horizontal=horizontal, vertical=vertical, content=content)
         self._create()
-        self._interface = self
 
     def create(self):
         self._impl = Gtk.ScrolledWindow()
+        self._impl._interface = self
 
     def _set_content(self, container, widget):
         self._impl.add_with_viewport(container._impl)

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -19,9 +19,9 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
 
     def _set_content(self, container, widget):
         if self._impl.get_child():
-            self._impl.remove(self._impl.get_child())
+            self._impl.get_child().destroy()
 
-        self._impl.add_with_viewport(container._impl)
+        self._impl.add(container._impl)
 
     def _set_app(self, app):
         if self._content:

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -21,7 +21,7 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
         if self._impl.get_child():
             self._impl.remove(self._impl.get_child())
 
-        self._impl.add(container._impl)
+        self._impl.add_with_viewport(container._impl)
 
     def _set_app(self, app):
         if self._content:

--- a/toga_gtk/widgets/scrollcontainer.py
+++ b/toga_gtk/widgets/scrollcontainer.py
@@ -22,6 +22,7 @@ class ScrollContainer(ScrollContainerInterface, WidgetMixin):
             self._impl.get_child().destroy()
 
         self._impl.add(container._impl)
+        self._impl.show_all()
 
     def _set_app(self, app):
         if self._content:

--- a/toga_gtk/window.py
+++ b/toga_gtk/window.py
@@ -67,3 +67,6 @@ class Window(WindowInterface):
             width=allocation.width,
             height=allocation.height
         )
+
+    def close(self):
+        self._impl.close()

--- a/toga_gtk/window.py
+++ b/toga_gtk/window.py
@@ -21,6 +21,10 @@ class Window(WindowInterface):
         self._impl = self._IMPL_CLASS()
         self._impl.connect("delete-event", self._on_close)
         self._impl.set_default_size(self._size[0], self._size[1])
+        self._set_title(title)
+
+    def _set_title(self, title):
+        self._impl.set_title(self.title)
 
     def _set_app(self, app):
         app._impl.add_window(self._impl)

--- a/toga_gtk/window.py
+++ b/toga_gtk/window.py
@@ -21,10 +21,9 @@ class Window(WindowInterface):
         self._impl = self._IMPL_CLASS()
         self._impl.connect("delete-event", self._on_close)
         self._impl.set_default_size(self._size[0], self._size[1])
-        self._set_title(title)
 
     def _set_title(self, title):
-        self._impl.set_title(self.title)
+        self._impl.set_title(title)
 
     def _set_app(self, app):
         app._impl.add_window(self._impl)


### PR DESCRIPTION
Bugs fixed:

- `Button.on_press` meaning that the previous on_press settings would still exist -- this does have a warning in the console from GTK, but it seems to work?
- `ScrollContainer.content = X` causing an exception in the console
- `ScrollContainer.content = X` meaning X wasn't displayed
- `Window.close()` not existing